### PR TITLE
Build library on CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import ./nixpkgs.nix {}
+, compiler ? "ghc865"
+}:
+
+let
+  inherit (import ./gitignoreSource.nix { inherit (pkgs) lib; }) gitignoreSource;
+in
+  pkgs.haskell.lib.overrideCabal (pkgs.haskell.packages.${compiler}.callPackage ./haskell-xmpp.nix {}) (drv: {
+    src = gitignoreSource ./.;
+    configureFlags = ["-f-library-only"];
+    doCheck = false;
+    testHaskellDepends = [];
+    testToolDepends = [];
+    doHaddock = false;
+    enableLibraryProfiling = false;
+    enableSeparateDataOutput = false;
+    enableSharedExecutables = false;
+    isLibrary = false;
+    postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
+  })
+

--- a/gitignoreSource.nix
+++ b/gitignoreSource.nix
@@ -1,0 +1,9 @@
+let
+  owner = "hercules-ci";
+  repo = "gitignore";
+  rev = "f9e996052b5af4032fe6150bba4a6fe4f7b9d698";
+in
+  import (builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = "sha256:0jrh5ghisaqdd0vldbywags20m2cxpkbbk5jjjmwaw0gr8nhsafv";
+  })

--- a/haskell-xmpp.nix
+++ b/haskell-xmpp.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, array, base, blaze-markup, HaXml, html, mtl
+, network, polyparse, pretty, random, regex-compat, stdenv, stm
+, text, utf8-string, uuid, xml-conduit, xml-hamlet
+}:
+mkDerivation {
+  pname = "haskell-xmpp";
+  version = "1.0.2";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    array base blaze-markup HaXml html mtl network polyparse pretty
+    random regex-compat stm text utf8-string uuid xml-conduit
+    xml-hamlet
+  ];
+  homepage = "http://patch-tag.com/r/adept/haskell-xmpp/home";
+  description = "Haskell XMPP (eXtensible Message Passing Protocol, a.k.a. Jabber) library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  owner = "NixOS";
+  repo = "nixpkgs";
+  rev = "b2448a9fde1225c3681e576ab4d35d68631ca75e";
+  url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+in
+  import (builtins.fetchTarball url)


### PR DESCRIPTION
This gets the library building on CI. If this project had tests, we could run those too.