### PR TITLE
Refactor JID to GADT with data-kind and references to spec

### DIFF
--- a/src/Network/XMPP/Concurrent.hs
+++ b/src/Network/XMPP/Concurrent.hs
@@ -94,4 +94,3 @@ connPersist h = do
   debugIO "<space added>"
   threadDelay 30000000
   connPersist h
-    

--- a/src/Network/XMPP/Core.hs
+++ b/src/Network/XMPP/Core.hs
@@ -25,7 +25,7 @@ import Text.XML.HaXml              (Element(Elem), mkElemAttr, Content (CElem),
                                     QName(N))
 import Text.XML.HaXml.Posn         (Posn, noPos)
 
-import Network.XMPP.Sasl (saslAuth)
+import Network.XMPP.Sasl           (saslAuth)
 import Network.XMPP.Print
 import Network.XMPP.Stream
 import Network.XMPP.Types
@@ -41,7 +41,7 @@ initiateStream :: Handle
                -> Username -- ^ Username to use
                -> Password -- ^ Password to use
                -> Resource -- ^ Resource to use
-               -> XmppMonad (JID '[ 'Name, 'Resource ])
+               -> XmppMonad (JID 'NodeResource)
 initiateStream h server username password resrc =
   do liftIO $ hSetBuffering h NoBuffering
      resetStreamHandle h
@@ -71,7 +71,7 @@ initiateStream h server username password resrc =
      void startM
 
      -- Bind this session to resource
-     void $ xtractM "/stream:features/bind" -- `catch` (fail "Binding is not proposed")     
+     void $ xtractM "/stream:features/bind" -- `catch` (fail "Binding is not proposed")
 
      iqSend "bind1" Set 
                 [ mkElemAttr "bind" [ strAttr "xmlns" "urn:ietf:params:xml:ns:xmpp-bind" ]

--- a/src/Network/XMPP/XEP/MUC.hs
+++ b/src/Network/XMPP/XEP/MUC.hs
@@ -45,11 +45,11 @@ queryForAssociatedServices jid srv uuid =
 noelem :: Content Posn
 noelem = CElem (Elem (N "root") [] []) noPos
 
-enterRoom :: JID '[] -> UUID -> Stanza 'Presence
+enterRoom :: JID 'NodeResource -> UUID -> Stanza 'Presence
 enterRoom jid uuid =
     MkPresence
         { pFrom     = Nothing
-        , pTo       = Just jid
+        , pTo       = Just $ SomeJID jid
         , pId       = toString uuid
         , pType     = Default
         , pShowType = Available
@@ -65,11 +65,11 @@ enterRoom jid uuid =
                    ]
         }
 
-leaveRoom :: JID '[] -> UUID -> Stanza 'Presence
+leaveRoom :: JID 'NodeResource -> UUID -> Stanza 'Presence
 leaveRoom jid uuid =
     MkPresence
         { pFrom     = Nothing
-        , pTo       = Just jid
+        , pTo       = Just $ SomeJID jid
         , pId       = toString uuid
         , pType     = Unavailable
         , pShowType = Available
@@ -78,11 +78,11 @@ leaveRoom jid uuid =
         , pExt      = []
         }
 
-destroyRoom :: JID '[] -> JID '[] -> UUID -> Stanza 'IQ
+destroyRoom :: JID 'NodeResource -> JID 'Resource -> UUID -> Stanza 'IQ
 destroyRoom from to uuid =
     MkIQ
-        { iqFrom = Just from
-        , iqTo   = Just to
+        { iqFrom = Just $ SomeJID from
+        , iqTo   = Just $ SomeJID to
         , iqId   = toString uuid
         , iqType = Set
         , iqBody = [ head $ ($noelem) $


### PR DESCRIPTION
I tried to add typed JID definition according to specification, and the most convenient thing (by my feelings) - is GADT with data-kind parameter.

Specification [defines JID](https://xmpp.org/extensions/xep-0029.html#sect-idm45723967532368) as entity with 3 components. And only two of them are optional.
So all we have is:

- node-domain-resource
- domain-resource
- node-domain

It is still unclear for me, which types of jids possible to use in different requests (spec is not clear enough about this), but it is still convenient to have `SomeJID` for not clear cases, which JID we should use :)

@johnz-at-riskbook what do you think? Do I correctly understood your point about JID usage?
Should I add transition functions like `JID 'Domain -> NodeId -> JID 'Node`? Or we are ok with manual extending of particular jids? :)