### PR TITLE
Add handling of stream ending

### DIFF
--- a/src/Network/XMPP/Concurrent.hs
+++ b/src/Network/XMPP/Concurrent.hs
@@ -58,7 +58,7 @@ runThreaded a = do
         eiMsg <- parseM
         case eiMsg of
           Right m -> liftIO . atomically . writeTChan in' $ m
-          Left err -> liftIO $ print $ "Error in thread: " <> err
+          Left err -> liftIO $ print $ "Error in thread: " <> show err
       loopWrite s out' =
         void $ runXmppMonad $ do
           put s


### PR DESCRIPTION
I added handling of stream ending: it is just an `</stream:stream>` element, so attempt to parse such lexemes caused an errors. I added handling of this case. This can happen when user connects in second time while other connection for this user is alive, and ejabberd automatically will close first connection. So it is important to be able to parse this element, and also to differ this error from another, because after closing of stream we cannot read anymore from handle, so I added typed errors. 